### PR TITLE
feat(edo-srp): add new ontology classes and config

### DIFF
--- a/transitional/edo-srp/edo-subsea-rigid-pipes.properties
+++ b/transitional/edo-srp/edo-subsea-rigid-pipes.properties
@@ -1,0 +1,5 @@
+#Fri May 15 17:22:47 BRT 2026
+jdbc.password=
+jdbc.user=
+jdbc.url=
+jdbc.driver=

--- a/transitional/edo-srp/edo-subsea-rigid-pipes.ttl
+++ b/transitional/edo-srp/edo-subsea-rigid-pipes.ttl
@@ -2991,6 +2991,22 @@ edo:ConnSize rdf:type owl:Class ;
              edo:hasValueCardinality edo:SingleValue .
 
 
+###  https://w3id.org/energy-domain/edo#ConnectionAssembly
+edo:ConnectionAssembly rdf:type owl:Class ;
+                       rdfs:subClassOf edo:GroupingElements ,
+                                       edo:IfcInstanciableElement ;
+                       dcterms:identifier "ConnectionAssembly" ;
+                       skos:definition "Assembly composed of multiple connection-related components that together perform a mechanical sealing or fastening function."@en ,
+                                       "Conjunto composto por múltiplos componentes relacionados à conexão que, em conjunto, desempenham função de vedação ou fixação mecânica."@pt-br ;
+                       skos:prefLabel "Conjunto de conexão"@pt-br ,
+                                      "Connection assembly"@en ;
+                       edo:entityStatus "NEW" ;
+                       edo:hasDiscipline edo:SubseaRigidPipesEngineering ;
+                       edo:ifc_equivalentClass "IfcElementAssembly" ;
+                       edo:ifc_objectType "ConnectionAssembly" ;
+                       edo:ifc_predefinedType "USERDEFINED" .
+
+
 ###  https://w3id.org/energy-domain/edo#ConnectionModule
 edo:ConnectionModule rdf:type owl:Class ;
                      rdfs:subClassOf edo:LineTerminationModule ;
@@ -4022,6 +4038,21 @@ edo:DisplacedVolume rdf:type owl:Class ;
                     edo:hasUnit unit:M3 ,
                                 edo:M3 ;
                     edo:hasValueCardinality edo:SingleValue .
+
+
+###  https://w3id.org/energy-domain/edo#DistributionConnectionPoint
+edo:DistributionConnectionPoint rdf:type owl:Class ;
+                                rdfs:subClassOf edo:FluidPort ,
+                                                edo:IfcInstanciableElement ;
+                                dcterms:identifier "DistributionConnectionPoint" ;
+                                skos:definition "Localização em um modelo que indica o ponto específico onde os componentes de distribuição de fluido são conectados. O Ponto de Conexão de Distribuição fornece informações precisas para a montagem e instalação desses componentes, garantindo o alinhamento adequado e a funcionalidade dentro do sistema. Este ponto é crucial para definir a interface entre os elementos de distribuição de fluido em sistemas submarinos ou outros sistemas de manuseio de fluido."@pt-br ,
+                                                "Location in a model that indicates the specific point where fluid distribution components are connected. The Distribution Connection Point provides precise information for the assembly and installation of these components, ensuring proper alignment and functionality within the system. This point is critical for defining the interface between fluid distribution elements in subsea or other fluid-handling systems."@en ;
+                                skos:prefLabel "Conexão de Distribuição"@pt-br ,
+                                               "Distribution Connection Point"@en ;
+                                edo:hasDiscipline edo:SubseaRigidPipesEngineering ;
+                                edo:ifc_equivalentClass "IfcDistributionPort" ;
+                                edo:ifc_objectType "DistributionConnectionPoint" ;
+                                edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#DistributionModule
@@ -21284,9 +21315,11 @@ edo:_CAT-PhysicalCharacteristic rdf:type owl:Class ;
 edo:_CAT-Specification rdf:type owl:Class ;
                        rdfs:subClassOf edo:DomainAttribute .
 
+
 ###  https://w3id.org/energy-domain/edo#_CAT-SubseaPipelineExecutiveProperties
 edo:_CAT-SubseaPipelineExecutiveProperties rdf:type owl:Class ;
-                       rdfs:subClassOf edo:DomainAttribute .
+                                           rdfs:subClassOf edo:DomainAttribute .
+
 
 ###  https://w3id.org/energy-domain/edo#_CAT-TechnicalDetail
 edo:_CAT-TechnicalDetail rdf:type owl:Class ;
@@ -21594,20 +21627,20 @@ unit:KiloN-M-PER-DEG rdf:type owl:NamedIndividual ,
                                         [ qudt:exponent 1 ;
                                           qudt:hasUnit unit:M
                                         ] ,
+                                        [ qudt:exponent 1 ;
+                                          qudt:hasUnit unit:M
+                                        ] ,
+                                        [ qudt:exponent 1 ;
+                                          qudt:hasUnit unit:M
+                                        ] ,
+                                        [ qudt:exponent 1 ;
+                                          qudt:hasUnit unit:M
+                                        ] ,
+                                        [ qudt:exponent 1 ;
+                                          qudt:hasUnit unit:M
+                                        ] ,
                                         [ qudt:exponent -1 ;
                                           qudt:hasUnit unit:DEG
-                                        ] ,
-                                        [ qudt:exponent 1 ;
-                                          qudt:hasUnit unit:M
-                                        ] ,
-                                        [ qudt:exponent 1 ;
-                                          qudt:hasUnit unit:M
-                                        ] ,
-                                        [ qudt:exponent 1 ;
-                                          qudt:hasUnit unit:M
-                                        ] ,
-                                        [ qudt:exponent 1 ;
-                                          qudt:hasUnit unit:M
                                         ] ,
                                         [ qudt:exponent 1 ;
                                           qudt:hasUnit unit:M
@@ -22319,11 +22352,11 @@ edo:MilliGM_KOH-PER-GM rdf:type owl:NamedIndividual ,
                                 edo:DomainUnit ;
                        qudt:conversionMultiplier "0.001"^^xsd:double ;
                        qudt:definedUnitOfSystem sou:SI ;
-                       qudt:hasFactorUnit [ qudt:exponent -1 ;
-                                            qudt:hasUnit unit:GM
-                                          ] ,
-                                          [ qudt:exponent 1 ;
+                       qudt:hasFactorUnit [ qudt:exponent 1 ;
                                             qudt:hasUnit unit:MilliGM
+                                          ] ,
+                                          [ qudt:exponent -1 ;
+                                            qudt:hasUnit unit:GM
                                           ] ;
                        qudt:hasQuantityKind qudt:Dimensionless ;
                        qudt:symbol "mgKOH/g" ;
@@ -22338,14 +22371,14 @@ edo:N-M2-PER-RAD rdf:type owl:NamedIndividual ,
                           edo:DomainUnit ;
                  qudt:conversionMultiplier 1.0 ;
                  qudt:definedUnitOfSystem sou:SI ;
-                 qudt:hasFactorUnit [ qudt:exponent -2 ;
+                 qudt:hasFactorUnit [ qudt:exponent -1 ;
+                                      qudt:hasUnit unit:RAD
+                                    ] ,
+                                    [ qudt:exponent -1 ;
+                                      qudt:hasUnit unit:RAD
+                                    ] ,
+                                    [ qudt:exponent -2 ;
                                       qudt:hasUnit unit:M
-                                    ] ,
-                                    [ qudt:exponent -1 ;
-                                      qudt:hasUnit unit:RAD
-                                    ] ,
-                                    [ qudt:exponent -1 ;
-                                      qudt:hasUnit unit:RAD
                                     ] ,
                                     [ qudt:exponent -2 ;
                                       qudt:hasUnit unit:M


### PR DESCRIPTION
Add two new OWL classes: ConnectionAssembly and DistributionConnectionPoint to the subsea rigid pipes ontology. Update QUDT unit factor definitions, fix TTL comment formatting and whitespace, and add the initial properties configuration file for the module.